### PR TITLE
turff: register using crops-codi linked container info if available

### DIFF
--- a/turff/turff.py
+++ b/turff/turff.py
@@ -17,6 +17,27 @@ from flask import json
 import hashlib
 import requests
 import argparse
+import os
+
+def getDefaultIP():
+    '''returns CROPS-CODI linked ip addr or 0.0.0.0 as default'''
+    try:
+        s=os.environ['CROPS_CODI_PORT']
+        ip = s.split(':')[1].replace("/","")
+    except:
+        ip="0.0.0.0"
+
+    return ip
+
+def getDefaultPort():
+    '''returns CROPS-CODI linked port or 10000 as default'''
+    try:
+        s=os.environ['CROPS_CODI_PORT']
+        port = int(s.split(':')[2])
+    except:
+        port=10000
+
+    return port
 
 class Turff():
     '''Turff is a toolchain description utility'''
@@ -56,10 +77,10 @@ class Turff():
         '''
         parser = argparse.ArgumentParser(
                 description='TURFF command line arguments')
-        parser.add_argument('--ip', default="0.0.0.0",
-                help='codi ip address (default: 0.0.0.0)')
-        parser.add_argument('--port', default=10000, type=int,
-                help='codi port (default: 10000)')
+        parser.add_argument('--ip', default=getDefaultIP(),
+                            help='codi ip address (default: %s)'%(getDefaultIP()))
+        parser.add_argument('--port', default=getDefaultPort(), type=int,
+                            help='codi port (default: %s'%(getDefaultPort()))
         parser.add_argument('--jsonRoot', default="/opt/poky/.crops/",
                 help='root directory for json descriptors (default:/opt/poky/.crops)')
         parser.add_argument('--dockerURL', default="unix:///var/run/docker.sock",


### PR DESCRIPTION
  the preferred way to start up the containers is:
    docker  run -d -v /var/run/docker.sock:/var/run/docker.sock -p 10000:10000 --name=crops-codi bavery/codi
    docker run -d --link crops-codi crops/<toolchain_name>:<version>
  if no link informaton for crops-codi exists we default to localhost:10000

Signed-off-by: bavery brian.avery@intel.com
