### PR TITLE
codi: convert codi to wsgi application served with gunicorn

### DIFF
--- a/codi/codi.py
+++ b/codi/codi.py
@@ -133,15 +133,3 @@ class Codi() :
             return "Success"
         else:
             return "Error"
-
-    def get_arg_parser(self):
-        '''Create CODI command line argument parser
-        returns: codi arguments
-        '''
-        parser = argparse.ArgumentParser(
-                description='CODI command line arguments')
-        parser.add_argument('--ip', default="0.0.0.0",
-                help='codi ip address (default: 0.0.0.0)')
-        parser.add_argument('--port', default=10000, type=int,
-                help='codi port (default: 10000)')
-        return parser.parse_args()

--- a/launchers/codi-launcher.py
+++ b/launchers/codi-launcher.py
@@ -28,10 +28,7 @@ def register_codi_routes (app):
     app.add_url_rule('/codi/remove-image', 'remove-image', codi.remove_image)
     app.add_url_rule('/codi/remove-toolchain', 'remove_toolchain', codi.remove_toolchain)
 
-if __name__ == '__main__':
-    app = Flask(__name__)
-    db = codiDB.CodiDB(config.CODI_DB)
-    codi = codi.Codi(app, db)
-    register_codi_routes(app)
-    codi_args = codi.get_arg_parser()
-    app.run(host=codi_args.ip, port=codi_args.port, debug=True)
+app = Flask(__name__)
+db = codiDB.CodiDB(config.CODI_DB)
+codi = codi.Codi(app, db)
+register_codi_routes(app)

--- a/launchers/turff-launcher.py
+++ b/launchers/turff-launcher.py
@@ -18,11 +18,9 @@ from flask import Response
 from utils.globs import config
 import os
 
-if __name__ == '__main__':
+def toolchain_reg(turff):
     response = Response()
-    turff = turff.Turff()
     turff_args = turff.get_arg_parser()
-
     for jfile in os.listdir(turff_args.jsonRoot + "/"):
         if jfile.endswith(".json"):
             jdata = turff.load_json(turff_args.jsonRoot +
@@ -38,3 +36,14 @@ if __name__ == '__main__':
                 print("Registration successful : " + jfile)
             else:
                 print("Registration failed : " + jfile)
+                return False
+    return True
+
+
+if __name__ == '__main__':
+    turff = turff.Turff()
+    retries = turff.get_arg_parser().retries
+    success = False
+    while (bool(retries) & (not success)):
+        success=toolchain_reg(turff)
+        retries -= 1

--- a/turff/turff.py
+++ b/turff/turff.py
@@ -85,4 +85,6 @@ class Turff():
                 help='root directory for json descriptors (default:/opt/poky/.crops)')
         parser.add_argument('--dockerURL', default="unix:///var/run/docker.sock",
                 help='Docker Engine URL (default:unix:///var/run/docker.sock)')
+        parser.add_argument('--retries', default=3, type=int,
+                help='Number of times to retry to register a toolchain (default: 5')
         return parser.parse_args()


### PR DESCRIPTION
The flask server is blocking and synchronous and we need to
be able to handle multiple simultaneous toolchain
registrations asynchronously. Gunicorn is used as a WSGI server to spawn
multiple flask application workers.

Example: Spawn 4 workers listening on 0.0.0.0:10000

gunicorn -w 4 -b 0.0.0.0:10000 codi-launcher:app

Signed-off-by: Todor Minchev todor.minchev@linux.intel.com
